### PR TITLE
Add geni coefficient as an inequality measure for the statistical parity. 

### DIFF
--- a/utils/score.py
+++ b/utils/score.py
@@ -135,8 +135,8 @@ def statistical_parity(edges, y, metric = "std"):
     Mdenom = np.outer(Nk, Nk) - np.diag(Nk)
     P = M / Mdenom
     # Calculate the statistical parity
-    
-    probs = P[np.triu_indices(K)]
+
+    probs = np.array(P[np.triu_indices(K)]).reshape(-1)
     if metric == "std":
         parity = np.std(probs)
     elif metric == "gini":


### PR DESCRIPTION
The original statistical parity quantifies the inequality in the edge probability distribution using the standard deviation. The standard deviation is on the same scale as the edge probability, so the standard deviation tends to be smaller for sparse networks and possibly loses the sensitivity.

As an alternative inequality measure, I added "geni" coefficient as a metric for inequality. 